### PR TITLE
Correct the safe-paths.json example

### DIFF
--- a/Safe-Places-Server.md
+++ b/Safe-Places-Server.md
@@ -198,7 +198,6 @@ Consumed by the Safe Paths client application.  This requires no authentication.
 
 ```json
 {
-  "data": {
     "authority_name": "Fake Organization",
     "concern_points": [
       {
@@ -214,7 +213,6 @@ Consumed by the Safe Paths client application.  This requires no authentication.
     ],
     "info_website": "https://www.something.gov/path/to/info/website",
     "publish_date_utc": "1584924583"
-  }
 }
 ```
 </td></tr>


### PR DESCRIPTION
The safe-paths.json incorrectly documented the output to include a "data": entity
which wrapped the content.  The Safe Paths app does not expect this.