### PR TITLE
Fix bug with importing case data (#100)

### DIFF
--- a/src/components/PathEditor/Dropzone.js
+++ b/src/components/PathEditor/Dropzone.js
@@ -7,7 +7,7 @@ import { Button } from '@wfp/ui';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFolderPlus } from '@fortawesome/pro-solid-svg-icons';
 
-function MyDropzone({ importPathTrigger }) {
+function MyDropzone({ importPathTrigger, currentCase }) {
   const onDrop = useCallback(
     acceptedFiles => {
       acceptedFiles.forEach(file => {
@@ -18,13 +18,13 @@ function MyDropzone({ importPathTrigger }) {
         reader.onload = () => {
           // Do whatever you want with the file contents
           const binaryStr = reader.result;
-          importPathTrigger(JSON.parse(binaryStr));
+          importPathTrigger(JSON.parse(binaryStr), currentCase);
           console.log(JSON.parse(binaryStr));
         };
         reader.readAsText(file);
       });
     },
-    [importPathTrigger],
+    [importPathTrigger, currentCase],
   );
   const { getRootProps, getInputProps } = useDropzone({ onDrop });
 
@@ -40,12 +40,14 @@ function MyDropzone({ importPathTrigger }) {
 
 const mapStateToProps = state => {
   return {
-    // track: getAllTracks(state)
+    currentCase: state.cases.currentCase,
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  importPathTrigger: data => dispatch(cases.actions.import(data)),
+  importPathTrigger: (points, currentCase) => {
+    dispatch(cases.actions.import({ points, currentCase }));
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(MyDropzone);

--- a/src/ducks/cases.js
+++ b/src/ducks/cases.js
@@ -15,12 +15,12 @@ export default createSlice({
     },
     import: (state, action) => {
       var points = {};
-      action.payload.forEach(element => {
+      action.payload.points.forEach(element => {
         const id = v4();
         element.id = id;
         points[id] = element;
       });
-      state.entries[action.payload.id].points = points;
+      state.entries[action.payload.currentCase].points = points;
       return state;
     },
     editEntry: (state, action) => {


### PR DESCRIPTION
## Overview
This fixes #100.

## Problem
On `line 23`, the property `id` is not on `payload`. This is because `payload` is an array of all the imported case data.
https://github.com/Path-Check/safeplaces-frontend/blob/b2284cbacffe39d41dda07fcd2c2ec8a6b30207f/src/ducks/cases.js#L16-L25

## Desired Behavior
On `line 23`, we want to replace `action.payload.id` with the identifier of the current case. The current case is the version 4 UUID, displayed in the URL bar after creating a new case.

![image](https://user-images.githubusercontent.com/48393820/82152712-351af500-9831-11ea-8e98-4ced30b209ab.png)

## Solution
I solve this issue by modifying the component in `Dropzone.js` so that it accepts the `currentCase` variable, which is passed by the Redux `mapStateToProps` function.

Then, when the user clicks on the "Import" button, the callback dispatches `currentCase` along with the imported points.

 