### PR TITLE
Use latest staging timestamp

### DIFF
--- a/src/components/_shared/RecordsTable/RecordsTablePublishing/Record/index.js
+++ b/src/components/_shared/RecordsTable/RecordsTablePublishing/Record/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
@@ -10,16 +9,8 @@ import moment from 'moment';
 import styles from './record.module.scss';
 import Checkbox from 'components/_shared/Checkbox/Checkbox';
 
-const Record = ({
-  id,
-  updatedAt,
-  state,
-  expiresAt,
-  onChange,
-  processingDate,
-  contact_tracer_id,
-}) => {
-  const processDateFriendly = moment(processingDate).format(
+const Record = ({ id, state, onChange, staged_at, contact_tracer_id }) => {
+  const processDateFriendly = moment(staged_at).format(
     'ddd, MMMM D, YYYY - h:ma',
   );
 
@@ -34,18 +25,11 @@ const Record = ({
       </th>
       <td colSpan="1">{id}</td>
       <td colSpan="2">
-        <time dateTime={processingDate}>{processDateFriendly}</time>
+        <time dateTime={staged_at}>{processDateFriendly}</time>
       </td>
       <td colSpan="2">{contact_tracer_id ? `${contact_tracer_id}` : 'N/A'}</td>
     </tr>
   );
-};
-
-Record.propTypes = {
-  id: PropTypes.number,
-  updatedAt: PropTypes.string,
-  status: PropTypes.string,
-  expiresIn: PropTypes.string,
 };
 
 export default Record;


### PR DESCRIPTION
Original build used `processingDate`, which no longer exists. I have updated the view to consume the correct timestamp; 

<img width="1061" alt="Screenshot 2020-06-16 at 10 07 51" src="https://user-images.githubusercontent.com/2306064/84785245-459dc700-afb9-11ea-8e31-577f7d1006bf.png">
`staged_at`.