### PR TITLE
Display Record IDs in Existing Records Table

### DIFF
--- a/src/components/_shared/RecordsTable/RecordsTableTrace/Record/index.js
+++ b/src/components/_shared/RecordsTable/RecordsTableTrace/Record/index.js
@@ -10,7 +10,7 @@ import casesActions from 'ducks/cases/actions';
 import { returnFormattedDate } from 'helpers/dateTime';
 
 const Record = ({
-  id,
+  caseId,
   updated_at,
   updatedAt,
   state,
@@ -34,15 +34,15 @@ const Record = ({
     <tr className={recordClasses}>
       <td colSpan="1">
         {!unpublished ? (
-          id
+          caseId
         ) : (
-          <button
-            className={styles.recordAction}
-            onClick={() => dispatch(casesActions.loadCasePoints(id))}
-          >
-            {id}
-          </button>
-        )}
+            <button
+              className={styles.recordAction}
+              onClick={() => dispatch(casesActions.loadCasePoints(caseId))}
+            >
+              {caseId}
+            </button>
+          )}
       </td>
       <td colSpan="2">
         <time dateTime={updated}>{updated}</time>
@@ -54,7 +54,7 @@ const Record = ({
 };
 
 Record.propTypes = {
-  id: PropTypes.number,
+  caseId: PropTypes.number,
   updatedAt: PropTypes.string,
   status: PropTypes.string,
   expiresIn: PropTypes.string,


### PR DESCRIPTION
Currently The Records Table isn't displaying Record Ids which makes it impossible to load a record

![Screen Shot 2020-06-17 at 1 44 05 PM](https://user-images.githubusercontent.com/20758953/84931460-d13e5300-b0a0-11ea-8a53-e7924587e523.png)

This is a fix for that