### PR TITLE
Add ID selector to each Map Marker/Pin

### DIFF
--- a/src/components/_shared/Map/Marker/index.js
+++ b/src/components/_shared/Map/Marker/index.js
@@ -89,7 +89,11 @@ const MapMarker = ({
 
   return (
     <Marker className={classes} latitude={latitude} longitude={longitude}>
-      <button onClick={handleClick} ref={markerRef}>
+      <button
+        onClick={handleClick}
+        ref={markerRef}
+        id={`map-marker-${pointId}`}
+      >
         <FontAwesomeIcon
           icon={faMapMarkerAlt}
           className={markerIcon}


### PR DESCRIPTION
Each marker rendered on the map will possess an `id` attribute populated with a unique, easy-to-read value; 
`<button id="map-marker-713">` - the integer is the pointId assigned to each individual point returned from the API.

This should allow QA to easily select a DOM element using the provided ID selector.