### PR TITLE
Apply date filtering after change

### DIFF
--- a/src/components/_shared/RedactorTools/DateSelector/index.js
+++ b/src/components/_shared/RedactorTools/DateSelector/index.js
@@ -66,27 +66,27 @@ const DateSelector = ({ dates }) => {
             min={0}
             max={dates.length - 1}
             steps={dates.length}
-            onChange={handleChange}
+            onAfterChange={handleChange}
           />
         ) : (
-            <Range
-              min={0}
-              max={dates.length - 1}
-              steps={dates.length}
-              allowCross={false}
-              onChange={handleChange}
-            />
-          )}
+          <Range
+            min={0}
+            max={dates.length - 1}
+            steps={dates.length}
+            allowCross={false}
+            onAfterChange={handleChange}
+          />
+        )}
       </div>
       <div className={dateSelectorDates}>
         {isSingleDate ? (
           <span className={sliderValue}>{singleDate}</span>
         ) : (
-            <>
-              <span className={sliderValue}>{dateRange[0]}</span>
-              <span className={sliderValue}>{dateRange[1]}</span>
-            </>
-          )}
+          <>
+            <span className={sliderValue}>{dateRange[0]}</span>
+            <span className={sliderValue}>{dateRange[1]}</span>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Currently whenever the user 'drags' the date range slider, the map attempts to re-render every time the knob's position changes. This significantly impacts performance and lags the entire interface.

This PR contains a fix for the reported issue; the date ranger slider now utilises the `onAfterChange` method which prevents unnecessary re-renders.

Demo can be found [here](https://drive.google.com/file/d/1o9GwVsQscl8XktTGXHlKiaOX1cSQ588M/view).

Relates to https://github.com/Path-Check/safeplaces-frontend/issues/103