### PR TITLE
Improving Map Drawing experience

### DIFF
--- a/src/components/_shared/Map/DrawEditor/index.js
+++ b/src/components/_shared/Map/DrawEditor/index.js
@@ -131,6 +131,17 @@ const DrawEditor = () => {
         clickRadius={10}
         onUpdate={map => handleUpdate(map)}
         featureStyle={({ feature, state }) => {
+          console.log(state);
+
+          if (state === 'UNCOMMITTED' || state === 'SELECTED') {
+            return {
+              stroke: '#4051DB',
+              strokeWidth: 1,
+              fill: 'rgba(105, 121, 248, 0.2)',
+              strokeDasharray: '5,5',
+            };
+          }
+
           return {
             stroke: '#4051DB',
             strokeWidth: 2,

--- a/src/components/_shared/Map/DrawEditor/index.js
+++ b/src/components/_shared/Map/DrawEditor/index.js
@@ -123,8 +123,12 @@ const DrawEditor = () => {
     <>
       <Editor
         ref={editorRef}
-        style={{ width: '100%', height: '100%' }}
-        clickRadius={12}
+        style={{
+          width: '100%',
+          height: '100%',
+          cursor: renderTools ? 'crosshair' : 'inherit',
+        }}
+        clickRadius={10}
         onUpdate={map => handleUpdate(map)}
         featureStyle={({ feature, state }) => {
           return {


### PR DESCRIPTION
I have made the following changes in an attempt to improve the map drawing experience;

- Change cursor to crosshair for clearer control when generating polygon.
- Modified styling when user is in 'drawing' mode.
- Modified styling when user has finished drawing a shape.

**Drawing**
<img width="895" alt="Screenshot 2020-06-24 at 15 10 19" src="https://user-images.githubusercontent.com/2306064/85617276-00b70780-b62d-11ea-8937-79ba8704c378.png">

**Completed shape**
<img width="874" alt="Screenshot 2020-06-24 at 15 10 27" src="https://user-images.githubusercontent.com/2306064/85617281-01e83480-b62d-11ea-98a7-72afe1529747.png">

Demo can be found [here](https://drive.google.com/file/d/19SD2-H2519_d_SbAXT7S5AejVH_75TBt/view)

[JIRA Ticket](https://pathcheck.atlassian.net/browse/PLACES-439)