### PR TITLE
Simplify record ID editing

### DIFF
--- a/src/components/_shared/RedactorTools/Header/EditRecordModal.js
+++ b/src/components/_shared/RedactorTools/Header/EditRecordModal.js
@@ -14,7 +14,7 @@ const EditRecordModal = ({
 }) => {
   return showModal ? (
     <Modal closeAction={() => setShowModal(false)}>
-      <Dialog width="650px">
+      <Dialog width="500px">
         <header>
           <h3>Edit Record ID</h3>
           <p>
@@ -34,7 +34,6 @@ const EditRecordModal = ({
           <Button type="button" onClick={onSubmit}>
             Save Record ID
           </Button>
-          <br />
           <Button type="button" secondary onClick={() => setShowModal(false)}>
             Cancel
           </Button>

--- a/src/components/_shared/RedactorTools/Header/header.module.scss
+++ b/src/components/_shared/RedactorTools/Header/header.module.scss
@@ -1,21 +1,20 @@
 .redactorToolsHeader {
   display: flex;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
 
   button {
     border: none;
     outline: none;
     background: none;
     cursor: pointer;
-    margin-right: 15px;
     font-size: 20px;
     padding: 0;
+    color: #9ba0aa;
   }
 }
 
-.selectedfaEllipsisVIcon {
-  position: absolute;
-  margin-left: 311px;
+.selectedEditAction {
+  margin: 0 0 0 auto;
 }
 
 header h3 {
@@ -23,20 +22,25 @@ header h3 {
   width: 275px;
   white-space: nowrap;
   overflow: hidden;
+  margin-left: 10px;
 }
 
 header p {
   margin-top: 20px;
 }
 
-.ModalButton Button {
-  margin-bottom: 10px;
-  font-size: 16px !important;
-  width: 250px;
-  height: 60px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
+.ModalButton {
+  display: flex;
+  flex-direction: column;
+
+  button {
+    width: 250px;
+    margin-bottom: 15px;
+    height: 60px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+  }
 }
 
 .inputText {

--- a/src/components/_shared/RedactorTools/Header/index.js
+++ b/src/components/_shared/RedactorTools/Header/index.js
@@ -2,23 +2,13 @@ import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  redactorToolsHeader,
-  selectedEditContextMenu,
-  selectedEditContextMenuAction,
-  selectedfaEllipsisVIcon,
-} from './header.module.scss';
+import { redactorToolsHeader, selectedEditAction } from './header.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faChevronLeft,
-  faEdit,
-  faEllipsisV,
-} from '@fortawesome/pro-solid-svg-icons';
+import { faChevronLeft, faPencilAlt } from '@fortawesome/pro-solid-svg-icons';
 import casesSelectors from 'ducks/cases/selectors';
 import caseAction from 'ducks/cases/actions';
 import EditRecordModal from './EditRecordModal';
 import applicationSelectors from 'ducks/application/selectors';
-import { useOnClickOutside } from 'hooks/useOnClickOutside';
 
 const RedactorToolsHeader = () => {
   const dispatch = useDispatch();
@@ -29,10 +19,7 @@ const RedactorToolsHeader = () => {
   const externalId = useSelector(state => casesSelectors.getExternalId(state));
   const mode = useSelector(state => applicationSelectors.getMode(state));
   const [showModal, setShowModal] = useState(false);
-  const [showEditRecordButton, setEditRecordButton] = useState(false);
   const [externalInputValue, setInputValue] = useState('');
-
-  useOnClickOutside(containerRef, () => setEditRecordButton(false));
 
   const onChangeHandler = event => {
     setInputValue(event.target.value);
@@ -50,27 +37,6 @@ const RedactorToolsHeader = () => {
   }
 
   const _id = activeCases.externalId || activeCases.caseId;
-
-  const EditRecordButton = () => (
-    <div className={selectedEditContextMenu}>
-      <ul>
-        <li>
-          <button
-            id="edit-record-id"
-            className={selectedEditContextMenuAction}
-            type="button"
-            onClick={() => {
-              setShowModal(true);
-              setEditRecordButton(false);
-            }}
-          >
-            <FontAwesomeIcon icon={faEdit} />
-            Edit Record ID
-          </button>
-        </li>
-      </ul>
-    </div>
-  );
 
   return (
     <>
@@ -99,15 +65,17 @@ const RedactorToolsHeader = () => {
         </h3>
         {mode === 'trace' && (
           <button
-            id="more-menu-button"
-            className={selectedfaEllipsisVIcon}
-            onClick={() => setEditRecordButton(true)}
+            id="edit-record-id"
+            className={selectedEditAction}
             type="button"
+            onClick={() => {
+              setShowModal(true);
+            }}
+            title="Edit Record ID"
           >
-            <FontAwesomeIcon icon={faEllipsisV} />
+            <FontAwesomeIcon icon={faPencilAlt} />
           </button>
         )}
-        {showEditRecordButton && <EditRecordButton />}
       </header>
 
       <EditRecordModal


### PR DESCRIPTION
User no longer required to hit a CTA just to be provided with a one option context menu.

<img width="366" alt="Screenshot 2020-06-30 at 13 50 23" src="https://user-images.githubusercontent.com/2306064/86159732-bcb67d80-bad8-11ea-867d-fbab43109151.png">
